### PR TITLE
feat: change listener definition to pass old & new state

### DIFF
--- a/packages/store/CHANGELOG.md
+++ b/packages/store/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Change
+
+- Refacto listener type & fct to pass old & new state instead of only old state
 
 ## [1.0.0]
 

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -1,6 +1,12 @@
 export type Reducer<State> = (state: State) => State;
 
-export type Listener<State> = (state: State) => void;
+export type Listener<State> = ({
+  oldState,
+  newState,
+}: {
+  oldState: State;
+  newState: State;
+}) => void;
 
 export type Unsubscribe = () => void;
 
@@ -93,13 +99,14 @@ export function create<State>(
 
     function apply(reducer: Reducer<State>) {
       return (): void => {
+        const oldState = state;
         state = reducer(state);
 
         // copying listeners list here to deals with unsubscribe nested in
         // subscription
         const localListeners = listeners.slice();
         localListeners.forEach((listener) => {
-          listener(state);
+          listener({ oldState, newState: state });
         });
       };
     }


### PR DESCRIPTION
What this PR does / why we need it:

Change listener args to allow new & old state

Which issue(s) this PR fixes:

- Fixes https://github.com/fp51/store-library/issues/72

